### PR TITLE
修复问题：部署 statistics-service-db-deployment 时，无密码的 postgresql 无法成功启动

### DIFF
--- a/kompose/test/statistics-service-db-deployment.yaml
+++ b/kompose/test/statistics-service-db-deployment.yaml
@@ -18,6 +18,9 @@ spec:
       containers:
       - image: docker.pkg.github.com/#{BOATHOUSE_ORG_NAME}#/boat-house/postgres:9.4
         name: statistics-service-db
+        env:
+          - name: POSTGRES_HOST_AUTH_METHOD
+            value: trust
       imagePullSecrets:
-      - name: regcred
+        - name: regcred
       restartPolicy: Always


### PR DESCRIPTION
fixes #231 