### PR TITLE
为 boat-house 增加了 helm chart

### DIFF
--- a/kompose/chart/Chart.yaml
+++ b/kompose/chart/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: boat-house
+description: A Helm chart for boat-house
+type: application
+version: 0.1.0
+appVersion: 1.16.0

--- a/kompose/chart/templates/deployment.yaml
+++ b/kompose/chart/templates/deployment.yaml
@@ -1,0 +1,52 @@
+{{- range $index, $svc := $.Values.serviceProfiles }}
+{{- if has $svc.name $.Values.services  }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $svc.name }}
+  labels:
+    rel: boat-house
+spec:
+  replicas: {{ $svc.replicas }}
+  selector: 
+    matchLabels:
+      app: {{ $svc.name }}
+  template:
+    metadata:
+      labels:
+        app: {{ $svc.name }}
+    spec:
+{{- if contains "product-service-db" $svc.name }}
+      volumes:
+        - name: mysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mysql-pv-claim
+{{- end }}
+      containers:
+      - name: {{ $svc.name }}
+        image: {{ $.Values.imageRepository }}/{{ $.Values.imageNamePrefix }}{{ $svc.imageName }}{{- if contains ":" $svc.imageName }}{{else}}:{{ $.Values.imageTag }}{{- end }}
+        {{- if contains "product-service-db" $svc.name }}
+        env:
+          - name: MYSQL_ROOT_PASSWORD
+            value: "P2ssw0rd"
+        volumeMounts:
+          - name: mysql-persistent-storage
+            mountPath: /var/lib/mysql
+        {{- end }}
+        {{- if contains "statistics-service-db" $svc.name }}
+        env:
+          - name: POSTGRES_HOST_AUTH_METHOD
+            value: trust
+        {{- end }}{{$appPort := int (toString ($svc.appPort)) }}
+        {{- if ne $appPort 0 }}
+        ports:
+          - containerPort: {{ $svc.appPort }}
+        {{- end }}
+    {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      restartPolicy: Always
+{{- end }}
+{{- end }}

--- a/kompose/chart/templates/service.yaml
+++ b/kompose/chart/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- range $index, $svc := $.Values.serviceProfiles }}
+{{- if has $svc.name $.Values.services  }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $svc.name }}
+  labels:
+    rel: boat-house
+spec:
+  type: {{ $svc.svcType }}
+  ports:
+    - port: {{ $svc.svcPort | default "80" }}
+      targetPort: {{ $svc.appPort }}
+      {{- if contains "NodePort" $svc.svcType }}
+      nodePort: {{ $svc.svcNodePort | default "{}" }}
+      {{- end }}
+  selector:
+    app: {{ $svc.name }}
+{{- end }}
+{{- end }}

--- a/kompose/chart/templates/storage.yaml
+++ b/kompose/chart/templates/storage.yaml
@@ -1,0 +1,20 @@
+{{- range $index, $svc := $.Values.serviceProfiles }}
+{{- if has $svc.name $.Values.services  }}
+{{- if contains "product-service-db" $svc.name }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pv-claim
+  labels:
+    rel: boat-house
+    app: {{ $svc.name }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+{{- end }}
+{{- end }}
+{{- end }}

--- a/kompose/chart/values.yaml
+++ b/kompose/chart/values.yaml
@@ -1,0 +1,64 @@
+
+imageRepository: docker.pkg.github.com/idcf-boat-house/boat-house
+imageNamePrefix: ''
+imageTag: master-86
+imagePullSecrets: []
+
+services:
+  - client
+  - management
+  - statistics-service-api
+  - statistics-service-worker
+  - product-service-api
+  - account-service-api
+
+
+serviceProfiles:
+  - name: client
+    imageName: client
+    replicas: 3
+    svcType: LoadBalancer
+    appPort: 8080
+    svcPort: 80
+  - name: management
+    imageName: management
+    replicas: 1
+    svcType: LoadBalancer
+    appPort: 4000
+    svcPort: 80
+  - name: product-service-db
+    imageName: mysql:5.6
+    replicas: 1
+    svcType: ClusterIP
+    appPort: 3306
+    svcPort: 3306
+  - name: product-service-api
+    imageName: product_service_api
+    replicas: 1
+    svcType: ClusterIP
+    appPort: 8080
+    svcPort: 8080
+  - name: statistics-service-db
+    imageName: postgres:9.4
+    replicas: 1
+    svcType: ClusterIP
+    appPort: 5432
+    svcPort: 5432
+  - name: statistics-service-redis
+    imageName: redis:alpine
+    replicas: 1
+    svcType: ClusterIP
+    appPort: 6379
+    svcPort: 6379
+  - name: statistics-service-api
+    imageName: statistics_service_api
+    replicas: 1
+    svcType: ClusterIP
+    appPort: 80
+    svcPort: 80
+  - name: statistics-service-worker
+    imageName: statistics_service_worker
+    replicas: 1
+    svcType: ClusterIP
+    appPort: 0
+    svcPort: 55555


### PR DESCRIPTION
使用 helm chart 部署 boat-house 可以更简便；同时，维护 yaml 时，无需针对多套环境维护多套。

使用 helm chart 部署 boat-house 分为两步：

1. 部署基础设施
```sh
ENV=test
kubectl create namespace boathouse-$ENV
helm install infra ./kompose/chart --namespace boathouse-$ENV \
        --set "services={product-service-db,statistics-service-db,statistics-service-redis},imageTag=master-86"

# 跟踪部署进度，等待 product-service-db 部署完成后导入初始数据
kubectl rollout status deploy/product-service-db -n boathouse-$ENV

PRODUCT_DB_POD=$(kubectl get pods -o=jsonpath='{.items[0].metadata.name}' -l app=product-service-db)
sleep 5
kubectl cp ./product-service/api/scripts/init.sql ${PRODUCT_DB_POD}:/root/init.sql -n boathouse-$ENV -c product-service-db
kubectl exec ${PRODUCT_DB_POD} -c product-service-db -n boathouse-$ENV -- /bin/bash -c 'mysql -u root -pP2ssw0rd < /root/init.sql'
```

2. 部署或更新微服务
```sh
ENV=test
TAG=master-86
# 如果只想部署或升级某一个微服务，把它的名字放在这里；否则将部署或升级所有微服务
SERVICES=

EXISTING=$(helm list --filter services -n boathouse-$ENV --short)
if [ -z "$EXISTING" ]; then
    helm install services ./kompose/chart --namespace boathouse-$ENV --set "services=$SERVICES,imageTag=$TAG"
else 
    helm upgrade services ./kompose/chart --namespace boathouse-$ENV --set "services=$SERVICES,imageTag=$TAG"
fi
```


